### PR TITLE
Added option to disable animation

### DIFF
--- a/lib/flutter_expanded_tile.dart
+++ b/lib/flutter_expanded_tile.dart
@@ -42,6 +42,7 @@ class ExpandedTileController extends ChangeNotifier {
 
   /// Getter for the current expansion state of the [ExpandedTile] widget.
   bool get isExpanded => _isExpanded;
+
   set _setExpanded(bool ex) {
     _isExpanded = ex;
     notifyListeners();
@@ -105,16 +106,21 @@ class ExpandedTileThemeData {
   final Color? headerSplashColor;
   final EdgeInsetsGeometry? headerPadding;
   final double? headerRadius;
+
   // leading
   final EdgeInsetsGeometry? leadingPadding;
+
   // title
   final EdgeInsetsGeometry? titlePadding;
+
   // trailing
   final EdgeInsetsGeometry? trailingPadding;
+
   ////? Content
   final Color? contentBackgroundColor;
   final EdgeInsetsGeometry? contentPadding;
   final double? contentRadius;
+
   const ExpandedTileThemeData({
     key,
     this.headerColor = const Color(0xfffafafa),
@@ -180,6 +186,7 @@ class ExpandedTile extends StatefulWidget {
   final Duration? expansionDuration; // default is 200ms
   final VoidCallback? onTap;
   final VoidCallback? onLongTap;
+  final bool enableAnimation; // default is true
   const ExpandedTile({
     key,
 ////? Header
@@ -202,6 +209,7 @@ class ExpandedTile extends StatefulWidget {
     this.expansionAnimationCurve = Curves.ease,
     this.onTap,
     this.onLongTap,
+    this.enableAnimation = true,
     // Misc
   }) : super(key: key);
 
@@ -228,6 +236,7 @@ class ExpandedTile extends StatefulWidget {
     final Duration? expansionDuration, // default is 200ms
     final VoidCallback? onTap,
     final VoidCallback? onLongTap,
+    final bool? enableAnimation,
   }) {
     return ExpandedTile(
       key: key,
@@ -247,10 +256,10 @@ class ExpandedTile extends StatefulWidget {
       controller: controller ?? this.controller,
       theme: theme ?? this.theme,
       expansionDuration: expansionDuration ?? this.expansionDuration,
-      expansionAnimationCurve:
-          expansionAnimationCurve ?? this.expansionAnimationCurve,
+      expansionAnimationCurve: expansionAnimationCurve ?? this.expansionAnimationCurve,
       onTap: onTap ?? this.onTap,
       onLongTap: onLongTap ?? this.onLongTap,
+      enableAnimation: enableAnimation ?? this.enableAnimation,
       // Misc
     );
   }
@@ -259,10 +268,10 @@ class ExpandedTile extends StatefulWidget {
   _ExpandedTileState createState() => _ExpandedTileState();
 }
 
-class _ExpandedTileState extends State<ExpandedTile>
-    with SingleTickerProviderStateMixin {
+class _ExpandedTileState extends State<ExpandedTile> with SingleTickerProviderStateMixin {
   late ExpandedTileController tileController;
   late bool _isExpanded;
+
   @override
   void initState() {
     tileController = widget.controller;
@@ -317,8 +326,7 @@ class _ExpandedTileState extends State<ExpandedTile>
                   },
             child: Container(
               decoration: BoxDecoration(
-                borderRadius:
-                    BorderRadius.circular(widget.theme!.headerRadius!),
+                borderRadius: BorderRadius.circular(widget.theme!.headerRadius!),
               ),
               padding: widget.theme!.headerPadding,
               child: Row(
@@ -356,24 +364,37 @@ class _ExpandedTileState extends State<ExpandedTile>
           height: widget.contentSeperator,
         ),
         //* Content
-        AnimatedSize(
-          duration: widget.expansionDuration!,
-          curve: widget.expansionAnimationCurve!,
-          child: Container(
-            child: !_isExpanded
-                ? null
-                : Container(
-                    decoration: BoxDecoration(
-                      color: widget.theme!.contentBackgroundColor,
-                      borderRadius:
-                          BorderRadius.circular(widget.theme!.contentRadius!),
-                    ),
-                    padding: widget.theme!.contentPadding,
-                    width: double.infinity,
-                    child: widget.content,
-                  ),
-          ),
-        ),
+        widget.enableAnimation
+            ? Container(
+                child: !_isExpanded
+                    ? null
+                    : Container(
+                        decoration: BoxDecoration(
+                          color: widget.theme!.contentBackgroundColor,
+                          borderRadius: BorderRadius.circular(widget.theme!.contentRadius!),
+                        ),
+                        padding: widget.theme!.contentPadding,
+                        width: double.infinity,
+                        child: widget.content,
+                      ),
+              )
+            : AnimatedSize(
+                duration: widget.expansionDuration!,
+                curve: widget.expansionAnimationCurve!,
+                child: Container(
+                  child: !_isExpanded
+                      ? null
+                      : Container(
+                          decoration: BoxDecoration(
+                            color: widget.theme!.contentBackgroundColor,
+                            borderRadius: BorderRadius.circular(widget.theme!.contentRadius!),
+                          ),
+                          padding: widget.theme!.contentPadding,
+                          width: double.infinity,
+                          child: widget.content,
+                        ),
+                ),
+              ),
       ],
     );
   }
@@ -384,8 +405,7 @@ enum TileListConstructor {
   seperated,
 }
 
-typedef ExpandedTileBuilder = ExpandedTile Function(
-    BuildContext context, int index, ExpandedTileController controller);
+typedef ExpandedTileBuilder = ExpandedTile Function(BuildContext context, int index, ExpandedTileController controller);
 
 /// An extension of the listview returning a list of [ExpandedTile] widgets which are
 /// Expansion tile similar to the list tile supports leading widget,
@@ -474,6 +494,7 @@ class _ExpandedTileListState extends State<ExpandedTileList> {
   late List<ExpandedTileController> tileControllers;
   late List<ExpandedTileController> openedTilesControllers;
   late ScrollController scrollController;
+
   @override
   void initState() {
     super.initState();
@@ -517,14 +538,11 @@ class _ExpandedTileListState extends State<ExpandedTileList> {
                               if (tileControllers[index].isExpanded) {
                                 if (openedTiles == widget.maxOpened) {
                                   openedTilesControllers.last.collapse();
-                                  openedTilesControllers
-                                      .remove(openedTilesControllers.last);
+                                  openedTilesControllers.remove(openedTilesControllers.last);
                                 }
-                                openedTilesControllers
-                                    .add(tileControllers[index]);
+                                openedTilesControllers.add(tileControllers[index]);
                               } else {
-                                openedTilesControllers
-                                    .remove(tileControllers[index]);
+                                openedTilesControllers.remove(tileControllers[index]);
                               }
                             });
             },
@@ -564,14 +582,11 @@ class _ExpandedTileListState extends State<ExpandedTileList> {
                               if (tileControllers[index].isExpanded) {
                                 if (openedTiles == widget.maxOpened) {
                                   openedTilesControllers.last.collapse();
-                                  openedTilesControllers
-                                      .remove(openedTilesControllers.last);
+                                  openedTilesControllers.remove(openedTilesControllers.last);
                                 }
-                                openedTilesControllers
-                                    .add(tileControllers[index]);
+                                openedTilesControllers.add(tileControllers[index]);
                               } else {
-                                openedTilesControllers
-                                    .remove(tileControllers[index]);
+                                openedTilesControllers.remove(tileControllers[index]);
                               }
                             });
             },

--- a/lib/flutter_expanded_tile.dart
+++ b/lib/flutter_expanded_tile.dart
@@ -177,7 +177,7 @@ class ExpandedTile extends StatefulWidget {
   final double? trailingRotation; // default is 90
 ////? Content
   final Widget content; // required
-  final double? contentSeperator; // default is 6.0
+  final double? contentSeparator; // default is 6.0
 ////? Misc
   final bool enabled;
   final ExpandedTileThemeData? theme; // default themedata
@@ -187,6 +187,13 @@ class ExpandedTile extends StatefulWidget {
   final VoidCallback? onTap;
   final VoidCallback? onLongTap;
   final bool enableAnimation; // default is true
+////? Checkbox
+  final bool checkable;
+  final bool isChecked;
+  final Color checkBoxColor;
+  final Color checkBoxActiveColor;
+  final Function(bool value)? onChecked;
+
   const ExpandedTile({
     key,
 ////? Header
@@ -200,7 +207,7 @@ class ExpandedTile extends StatefulWidget {
 
 ////? Content
     required this.content,
-    this.contentSeperator = 6.0,
+    this.contentSeparator = 6.0,
 ////? Misc
     required this.controller,
     this.enabled = true,
@@ -211,6 +218,12 @@ class ExpandedTile extends StatefulWidget {
     this.onLongTap,
     this.enableAnimation = true,
     // Misc
+////? Checkbox
+    this.isChecked = false,
+    this.checkable = false,
+    this.checkBoxColor = const Color(0xffffffff),
+    this.checkBoxActiveColor = const Color(0xff039be5),
+    this.onChecked,
   }) : super(key: key);
 
   /// Returns a new [ExpandedTile] widget with the same arguments unless stated otherwise.
@@ -227,7 +240,7 @@ class ExpandedTile extends StatefulWidget {
     final double? trailingRotation, // default is 90
 ////? Content
     final Widget? content, // required
-    final double? contentSeperator, // default is 6.0
+    final double? contentSeparator, // default is 6.0
 ////? Misc
     final bool? enabled,
     final ExpandedTileThemeData? theme, // default themedata
@@ -237,6 +250,11 @@ class ExpandedTile extends StatefulWidget {
     final VoidCallback? onTap,
     final VoidCallback? onLongTap,
     final bool? enableAnimation,
+    final bool? checkable,
+    final bool? isChecked,
+    final Color? checkBoxColor,
+    final Color? checkBoxActiveColor,
+    final Function(bool value)? onChecked,
   }) {
     return ExpandedTile(
       key: key,
@@ -250,7 +268,7 @@ class ExpandedTile extends StatefulWidget {
       trailingRotation: trailingRotation ?? this.trailingRotation,
 ////? Content
       content: content ?? this.content,
-      contentSeperator: contentSeperator ?? this.contentSeperator,
+      contentSeparator: contentSeparator ?? this.contentSeparator,
 ////? Misc
       enabled: enabled ?? this.enabled,
       controller: controller ?? this.controller,
@@ -260,6 +278,10 @@ class ExpandedTile extends StatefulWidget {
       onTap: onTap ?? this.onTap,
       onLongTap: onLongTap ?? this.onLongTap,
       enableAnimation: enableAnimation ?? this.enableAnimation,
+      checkable: checkable ?? this.checkable,
+      isChecked: isChecked ?? this.isChecked,
+      checkBoxColor: checkBoxColor ?? this.checkBoxColor,
+      onChecked: onChecked ?? this.onChecked,
       // Misc
     );
   }
@@ -271,6 +293,7 @@ class ExpandedTile extends StatefulWidget {
 class _ExpandedTileState extends State<ExpandedTile> with SingleTickerProviderStateMixin {
   late ExpandedTileController tileController;
   late bool _isExpanded;
+  late bool checkboxValue;
 
   @override
   void initState() {
@@ -283,6 +306,7 @@ class _ExpandedTileState extends State<ExpandedTile> with SingleTickerProviderSt
         });
       }
     });
+    checkboxValue = widget.isChecked;
     super.initState();
   }
 
@@ -344,24 +368,37 @@ class _ExpandedTileState extends State<ExpandedTile> with SingleTickerProviderSt
                       child: widget.title,
                     ),
                   ),
-                  Transform.rotate(
-                    angle: widget.trailingRotation != null
-                        ? _isExpanded
-                            ? angleToRad(widget.trailingRotation!)
-                            : 0
-                        : 0,
-                    child: Padding(
-                      padding: widget.theme!.trailingPadding!,
-                      child: widget.trailing,
-                    ),
-                  ),
+                  widget.checkable
+                      ? Checkbox(
+                          checkColor: widget.checkBoxColor,
+                          activeColor: widget.checkBoxActiveColor,
+                          value: checkboxValue,
+                          onChanged: (v) {
+                            setState(() {
+                              if (v != null) {
+                                checkboxValue = v;
+                                if (widget.onChecked != null) return widget.onChecked!(v);
+                              }
+                            });
+                          })
+                      : Transform.rotate(
+                          angle: widget.trailingRotation != null
+                              ? _isExpanded
+                                  ? angleToRad(widget.trailingRotation!)
+                                  : 0
+                              : 0,
+                          child: Padding(
+                            padding: widget.theme!.trailingPadding!,
+                            child: widget.trailing,
+                          ),
+                        ),
                 ],
               ),
             ),
           ),
         ),
         SizedBox(
-          height: widget.contentSeperator,
+          height: widget.contentSeparator,
         ),
         //* Content
         widget.enableAnimation
@@ -402,7 +439,7 @@ class _ExpandedTileState extends State<ExpandedTile> with SingleTickerProviderSt
 
 enum TileListConstructor {
   builder,
-  seperated,
+  separated,
 }
 
 typedef ExpandedTileBuilder = ExpandedTile Function(BuildContext context, int index, ExpandedTileController controller);
@@ -448,7 +485,7 @@ class ExpandedTileList extends StatefulWidget {
   final ScrollPhysics? physics;
   final EdgeInsetsGeometry? padding;
   final ExpandedTileBuilder itemBuilder;
-  final IndexedWidgetBuilder? seperatorBuilder;
+  final IndexedWidgetBuilder? separatorBuilder;
   final int itemCount;
   final String? restorationId;
   final int maxOpened;
@@ -467,14 +504,14 @@ class ExpandedTileList extends StatefulWidget {
   })  : assert(itemCount != 0),
         assert(maxOpened != 0),
         _constructor = TileListConstructor.builder,
-        seperatorBuilder = null,
+        separatorBuilder = null,
         super(key: key);
 
-  const ExpandedTileList.seperated({
+  const ExpandedTileList.separated({
     Key? key,
     required this.itemCount,
     required this.itemBuilder,
-    required this.seperatorBuilder,
+    required this.separatorBuilder,
     this.padding,
     this.physics,
     this.restorationId,
@@ -483,7 +520,7 @@ class ExpandedTileList extends StatefulWidget {
     this.maxOpened = 1,
   })  : assert(itemCount != 0),
         assert(maxOpened != 0),
-        _constructor = TileListConstructor.seperated,
+        _constructor = TileListConstructor.separated,
         super(key: key);
 
   @override
@@ -555,7 +592,7 @@ class _ExpandedTileListState extends State<ExpandedTileList> {
             physics: widget.physics,
             padding: widget.padding,
             separatorBuilder: (context, index) {
-              return widget.seperatorBuilder!(
+              return widget.separatorBuilder!(
                 context,
                 index,
               );

--- a/lib/flutter_expanded_tile.dart
+++ b/lib/flutter_expanded_tile.dart
@@ -365,20 +365,7 @@ class _ExpandedTileState extends State<ExpandedTile> with SingleTickerProviderSt
         ),
         //* Content
         widget.enableAnimation
-            ? Container(
-                child: !_isExpanded
-                    ? null
-                    : Container(
-                        decoration: BoxDecoration(
-                          color: widget.theme!.contentBackgroundColor,
-                          borderRadius: BorderRadius.circular(widget.theme!.contentRadius!),
-                        ),
-                        padding: widget.theme!.contentPadding,
-                        width: double.infinity,
-                        child: widget.content,
-                      ),
-              )
-            : AnimatedSize(
+            ? AnimatedSize(
                 duration: widget.expansionDuration!,
                 curve: widget.expansionAnimationCurve!,
                 child: Container(
@@ -394,6 +381,19 @@ class _ExpandedTileState extends State<ExpandedTile> with SingleTickerProviderSt
                           child: widget.content,
                         ),
                 ),
+              )
+            : Container(
+                child: !_isExpanded
+                    ? null
+                    : Container(
+                        decoration: BoxDecoration(
+                          color: widget.theme!.contentBackgroundColor,
+                          borderRadius: BorderRadius.circular(widget.theme!.contentRadius!),
+                        ),
+                        padding: widget.theme!.contentPadding,
+                        width: double.infinity,
+                        child: widget.content,
+                      ),
               ),
       ],
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -67,6 +67,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -80,7 +87,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -127,20 +134,13 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"


### PR DESCRIPTION
Added a new field ```enableAnimation``` to ```ExpandedTile``` constructor. Default value is true (working as usual). If value is set to false, it removes the AnimatedSize widget root of the content.

This removes unnecessary screen jank / flicker on complex widget trees, e.g. dynamic content widget, or nested ```ExpandedTile```s.